### PR TITLE
Create separate workflow for PR previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 on:
-  pull_request: 
-    branches:
-    - main
+  pull_request: {}
   push:
     branches:
     - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: bikeshed
+          DESTINATION: index.html
           SOURCE: spec.bs
           GH_PAGES_BRANCH: gh-pages
           BUILD_FAIL_ON: warning

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,30 @@
+name: Build
+concurrency: preview-${{ github.ref }}
+on:
+  pull_request:
+    paths:
+      - '**.bs'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: bikeshed
+          DESTINATION: .pr-preview-temp/preview--${{ github.ref }}/index.html
+          SOURCE: spec.bs
+          BUILD_FAIL_ON: warning
+      - uses: rossjrw/pr-preview-action@v1.2.0
+        with: 
+          source-dir: .pr-preview-temp/preview--${{ github.ref }}
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto
+          


### PR DESCRIPTION
We fix the destination of the spec's html file to fix the same problem as mentioned in https://github.com/WICG/fenced-frame/issues/53.

We also separate the building of the spec for PRs into a new workflow action with a different destination, so that they won't interfere with deployment on push.