### PR TITLE
Replace k-anonymity requirement for `selectURL()` input URLs with per per-page-load entropy bit budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,10 +461,6 @@ window.fence.reportEvent({eventType: 'visible',
 ```
 and it will send a POST message with the eventData. See the [fenced frame reporting document](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md) for more details.
 
-##### Event Level Reporting Limits
-This event-level reporting will allow for the embedding page's 1p data to be combined with the log2(num urls in selectURL) bits of third-party shared-storage data as soon as the report is sent. Since this can be used to build up a lot of information quite quickly, we're imposing some limits on event-level reporting while it's available. That is, event-level reporting via `reportEvent` can only consume up to 9 bits per top-level page navigation.
-
-
 ### Private aggregation
 
 Arbitrary cross-site data can be embedded into any aggregatable report, but that data is only readable via the aggregation service. Private aggregation protects the data with differential privacy. In order to adhere to the chosen differential privacy parameters, there are limits on the total amount of value the origin's reports can provide per time-period. The details of these limits are explored in the API's [explainer](https://github.com/alexmturner/private-aggregation-api#privacy-and-security).


### PR DESCRIPTION
We relax the requirement that the URLs used as inputs to `sharedStorage.selectURL()` be k-anonymous.

We currently have event-level reporting, which allows callers to associate a first-party identifier with up to three bits of cross-site data, in spite of any k-anonymity constraints. Meanwhile, requiring the input URLs to be k-anonymous increases the latency and complexity of `selectURL()` calls. Thus, we believe a k-anonymity requirement is of limited benefit and not worth the associated financial, performance, and utility costs.

Without k-anonymity, first-party information can be encoded in an input URL and thereby joined with cross-site data through the URL-selection process. We therefore add additional entropy limits to govern `selectURL()`'s use and mitigate its privacy impact.

In particular, we add two new types of entropy bit budgets whose lifetimes both coincide with that of a top-level navigation. The first budget will limit all calls from a given origin on that page during that page load to using up to 6 bits of entropy. The second will limit all calls across all origins on that page during that page load to consuming up to 12 bits of entropy.  These limits will be refreshed for new top-level navigations.
