### PR TITLE
Add support for writing from response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The shared storage worklet invocation methods (`addModule`, `run`, and `selectUR
 ### From response headers
 
 *  `set()`, `append()`, `delete()`, and `clear()` operations can be triggered via the HTTP response header `Shared-Storage-Write`.
+*  This may provide a large performance improvement over creating a cross-origin iframe and writing from there, if a network request is otherwise required.
 *   `Shared-Storage-Write` is a [List Structured Header](https://www.rfc-editor.org/rfc/rfc8941.html#name-lists).
     *   Each member of the [List](https://www.rfc-editor.org/rfc/rfc8941.html#name-lists) is a [String Item](https://www.rfc-editor.org/rfc/rfc8941.html#name-strings) or [Byte Sequence](https://www.rfc-editor.org/rfc/rfc8941.html#name-byte-sequences) denoting the operation to be performed, with any arguments for the operation as associated  [Parameters](https://www.rfc-editor.org/rfc/rfc8941.html#name-parameters).
     *   The order of [Items](https://www.rfc-editor.org/rfc/rfc8941.html#name-items) in the [List](https://www.rfc-editor.org/rfc/rfc8941.html#name-lists) is the order in which the operations will be performed.

--- a/README.md
+++ b/README.md
@@ -176,15 +176,15 @@ The shared storage worklet invocation methods (`addModule`, `run`, and `selectUR
         *   To pass a key and/or value that contains non-ASCII and/or non-printable characters, specify it as a [Byte Sequence](https://www.rfc-editor.org/rfc/rfc8941.html#name-byte-sequences).
             *   A [Byte Sequence](https://www.rfc-editor.org/rfc/rfc8941.html#name-byte-sequences) is delimited with colons and encoded using [base64](https://www.rfc-editor.org/rfc/rfc4648.html).
             *   For example:
-                *    `:aGVsbG8K:` encodes "hello\n" in [UTF-8](https://www.rfc-editor.org/rfc/rfc3629.html).
+                *    `:aGVsbG8K:` encodes "hello\n" in [UTF-8](https://www.rfc-editor.org/rfc/rfc3629.html) (where "\n" is the newline character).
                 *    `:2D3eAA==:` encodes "😀" in [UTF-16](https://www.rfc-editor.org/rfc/rfc2781.html).
             *   Remember that results returned via `get()` are [UTF-16](https://www.rfc-editor.org/rfc/rfc2781.html) [DOMStrings](https://webidl.spec.whatwg.org/#idl-DOMString).
 *  Performing operations via response headers requires a prior opt-in via a corresponding HTTP request header `Shared-Storage-Writable: ?1`.
 *  The request header can be sent along with `fetch` requests via specifying an option: `fetch(<url>, {sharedStorageWritable: true})`.
 *  The request header can alternatively be sent on document or image requests either 
     *   via specifying an content attribute, e.g.: 
-        *   `iframe src=[url] sharedstoragewritable></iframe>`
-        *    `img src=[url] sharedstoragewritable>`
+        *   `<iframe src=[url] sharedstoragewritable></iframe>`
+        *    `<img src=[url] sharedstoragewritable>`
     *   or via an equivalent IDL attribute, e.g.:
         *   `iframe.sharedStorageWritable = true`
         *   `img.sharedStorageWritable = true`.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The shared storage worklet invocation methods (`addModule`, `run`, and `selectUR
         *   To pass a key and/or value that contains non-ASCII and/or non-printable characters, specify it as a [Byte Sequence](https://www.rfc-editor.org/rfc/rfc8941.html#name-byte-sequences).
             *   A [Byte Sequence](https://www.rfc-editor.org/rfc/rfc8941.html#name-byte-sequences) is delimited with colons and encoded using [base64](https://www.rfc-editor.org/rfc/rfc4648.html).
             *   For example:
-                *    `:aGVsbG9cbg==:` encodes "hello\n" in [UTF-8](https://www.rfc-editor.org/rfc/rfc3629.html).
+                *    `:aGVsbG8K:` encodes "hello\n" in [UTF-8](https://www.rfc-editor.org/rfc/rfc3629.html).
                 *    `:2D3eAA==:` encodes "😀" in [UTF-16](https://www.rfc-editor.org/rfc/rfc2781.html).
             *   Remember that results returned via `get()` are [UTF-16](https://www.rfc-editor.org/rfc/rfc2781.html) [DOMStrings](https://webidl.spec.whatwg.org/#idl-DOMString).
 *  Performing operations via response headers requires a prior opt-in via a corresponding HTTP request header `Shared-Storage-Writable: ?1`.


### PR DESCRIPTION
We propose adding support to write to and delete from Shared Storage via a new HTTP response header `Shared-Storage-Write`, which will be able to  trigger `set()`, `append()`, `delete()`, and `clear()` operations. This will make our API surface more flexible and thereby provide greater utility to developers. Writing from headers should provide a large performance improvement over creating a cross-origin iframe and writing from there, if a network request is otherwise required.

To use the `Shared-Storage-Write` response header, the corresponding HTTP request header `Shared-Storage-Writable: ?1` must first be sent.

We plan to support making requests with the request header `Shared-Storage-Writable: ?1` by way of `fetch(<url>, {sharedStorageWritable: true})`, as well as a new content/IDL attribute pair `sharedstoragewritable`/`sharedStorageWritable` for iframes and images.