### PR TITLE
Update spec.bs to include Permissions Policy

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -153,9 +153,6 @@ spec: html; urlPrefix: https://en.wikipedia.org/wiki/Entropy_(information_theory
 spec: html; urlPrefix: https://github.com/privacysandbox/attestation
     type: dfn
         text: enrolled
-spec: html; urlPrefix: https://w3c.github.io/webappsec-permissions-policy/
-    type: dfn
-        text: is feature enabled; url: is-feature-enabled
 </pre>
 
 <style>
@@ -255,7 +252,9 @@ When {{Worklet/addModule()}} is called for a worklet, it will run [=check if add
     1. If |origin| is an [=opaque origin=], then return false.
     1. Let |globalObject| be the [=current realm=]'s [=global object=].
     1. [=Assert=] that |globalObject| is a {{Window}} or a {{SharedStorageWorkletGlobalScope}}.
-    1. If |globalObject| is a {{Window}}, and the result of executing [=is feature enabled|Is feature enabled in document for origin?=] on "[=PermissionsPolicy/shared-storage=]", |globalObject|'s [=associated Document=], and |origin| is "`Disabled`", return false.
+    1. Let |document| be |globalObject|'s [=associated Document=].
+    1. If |globalObject| is a {{Window}} and |document| is not [=allowed to use=] the "[=PermissionsPolicy/shared-storage=]" feature, return false.
+    1. If |globalObject| is a {SharedStorageWorkletGlobalScope}} and |document| is not [=fully active=], return false.
     1. If the result of running [=obtaining a site|obtain a site=] with |origin| is not [=enrolled=], then return false.
     1. If the result of running [=check if user preference setting allows access to shared storage=] from |environment| is false, then return false.
     1. Return true.
@@ -607,7 +606,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -630,7 +628,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -658,7 +655,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -676,7 +672,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -947,12 +942,10 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |resultPromise| be a new [=promise=].
     1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
-    1. Let |document| be |context|'s [=active document=].
-    1. If |document| is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. If the result of running [=determine whether shared storage is allowed=] on |environment| is false, return a [=promise rejected=] with a {{TypeError}}.
-    1. Let |origin| be |document|'s [=url/origin=].
-    1. If the result of executing [=is feature enabled|Is feature enabled in document for origin?=] on "[=PermissionsPolicy/shared-storage-select-url=]", |document], and |origin| is "`Disabled`", return false.
+    1. Let |document| be |context|'s [=active document=].
+    1. If |document| is not [=allowed to use=] the "[=PermissionsPolicy/shared-storage-select-url=]" feature, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |worklet| be {{WindowSharedStorage}}'s {{WindowSharedStorage/worklet}}.
     1. If |worklet|'s [=global scopes|list of global scopes=] is [=list/empty=], then return a [=promise rejected=] with a {{TypeError}}.
     1. [=Assert=] that |worklet|'s [=global scopes|list of global scopes=] [=list/contains=] a single {{SharedStorageWorkletGlobalScope}}.
@@ -977,7 +970,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |indexPromise| be the result of running [=get the select-url result index=], given |worklet|, |name|, |urlList|, and |options|.
     1. [=Upon fulfillment=] of |indexPromise|, perform the following steps:
         1. Let |resultIndex| be the numerical value of |indexPromise|.
-        1. Let |remainingBudget| be the result of running [=determine remaining navigation budget=] with |environment| and |origin|.
+        1. Let |remainingBudget| be the result of running [=determine remaining navigation budget=] with |environment| and |document|'s [=url/origin=].
         1. [=Assert=] that |remainingBudget| is not undefined.
         1. Let |pendingBits| be the logarithm base 2 of |urlList|'s [=list/size=].
         1. If |pendingBits| is greather than |remainingBudget|, set |resultIndex| to [=default index=].
@@ -1036,7 +1029,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -1065,7 +1057,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -1094,7 +1085,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -1113,7 +1103,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -1135,7 +1124,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -1155,7 +1143,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{WorkletSharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
@@ -1174,9 +1161,9 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{WorkletSharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
-    1. Let |document| be |context|'s [=active document=].
-    1. If |document| is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
-    1. Let |origin| be |document|'s [=document/origin=].
+    1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
+    1. If the result of running [=determine whether shared storage is allowed=] on |environment| is false, return a [=promise rejected=] with a {{TypeError}}.
+    1. Let |origin| be |context|'s [=active document=]'s [=document/origin=].
     1. [=Assert=] that |origin| is not [=opaque origin|opaque=].
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].
     1. Let |realm| be the [=current realm=].
@@ -1203,7 +1190,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
     1. Let |queue| be |context|'s associated [=shared storage database|database=]'s [=shared storage database/shared storage database queue=].

--- a/spec.bs
+++ b/spec.bs
@@ -254,7 +254,6 @@ When {{Worklet/addModule()}} is called for a worklet, it will run [=check if add
     1. [=Assert=] that |globalObject| is a {{Window}} or a {{SharedStorageWorkletGlobalScope}}.
     1. Let |document| be |globalObject|'s [=associated Document=].
     1. If |globalObject| is a {{Window}} and |document| is not [=allowed to use=] the "[=PermissionsPolicy/shared-storage=]" feature, return false.
-    1. If |globalObject| is a {SharedStorageWorkletGlobalScope}} and |document| is not [=fully active=], return false.
     1. If the result of running [=obtaining a site|obtain a site=] with |origin| is not [=enrolled=], then return false.
     1. If the result of running [=check if user preference setting allows access to shared storage=] from |environment| is false, then return false.
     1. Return true.
@@ -1028,6 +1027,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If |value|'s [=string/length=] exceeds the [=value/maximum length=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
@@ -1056,6 +1056,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If |value|'s [=string/length=] exceeds the [=value/maximum length=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
@@ -1084,6 +1085,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If |key|'s [=string/length=] exceeds the [=key/maximum length=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
@@ -1102,6 +1104,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{WorkletSharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
@@ -1123,6 +1126,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If |key|'s [=string/length=] exceeds the [=key/maximum length=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
@@ -1142,6 +1146,8 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |promise| be a new [=promise=].
     1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{WorkletSharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
+    1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.
@@ -1161,6 +1167,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{WorkletSharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. If the result of running [=determine whether shared storage is allowed=] on |environment| is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |origin| be |context|'s [=active document=]'s [=document/origin=].
@@ -1189,6 +1196,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{WorkletSharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |context| be {{WorkletSharedStorage}}'s {{SharedStorageWorkletGlobalScope}}'s [=outside settings=]'s [=target browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. If |context|'s [=active window=]'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. Let |databaseMap| be the result of running [=obtain a shared storage bottle map=] for |environment|.
     1. If |databaseMap| is failure, then return a [=promise rejected=] with a {{TypeError}}.

--- a/spec.bs
+++ b/spec.bs
@@ -153,6 +153,9 @@ spec: html; urlPrefix: https://en.wikipedia.org/wiki/Entropy_(information_theory
 spec: html; urlPrefix: https://github.com/privacysandbox/attestation
     type: dfn
         text: enrolled
+spec: html; urlPrefix: https://w3c.github.io/webappsec-permissions-policy/
+    type: dfn
+        text: is feature enabled; url: is-feature-enabled
 </pre>
 
 <style>
@@ -237,11 +240,11 @@ Each {{SharedStorageWorklet}} has an associated boolean <dfn>addModule initiated
 
 Because adding multiple [=module scripts=] via {{Worklet/addModule()}} for the same {{SharedStorageWorklet}} would give the caller the ability to store data from [=Shared Storage=] in global variables defined in the [=module scripts=] and then exfiltrate the data through later call(s) to {{Worklet/addModule()}}, each {{SharedStorageWorklet}} can only call {{Worklet/addModule()}} once. The [=addModule initiated=] boolean makes it possible to enforce this restriction.
 
-When {{Worklet/addModule()}} is called for a worklet, it will run [=check if addModule allowed and update status=], and if the result is false, abort the remaining steps in the {{Worklet/addModule()}} call, as detailed in the [[#worklet-monkey-patch]].
+When {{Worklet/addModule()}} is called for a worklet, it will run [=check if addModule is allowed and update status=], and if the result is false, abort the remaining steps in the {{Worklet/addModule()}} call, as detailed in the [[#worklet-monkey-patch]].
 
   <div algorithm>
     To <dfn>check if user preference setting allows access to shared storage</dfn> from an [=environment settings object=] |environment|, run the following step:
-    1. Using values available in |environment| as needed, use an [=implementation-defined=] algorithm to return either true or false.
+    1. Using values available in |environment| as needed, perform an [=implementation-defined=] algorithm to return either true or false.
   </div>
 
   <div algorithm>
@@ -250,13 +253,16 @@ When {{Worklet/addModule()}} is called for a worklet, it will run [=check if add
     1. If |environment| is not a [=secure context=], then return false.
     1. Let |origin| be |environment|'s [=url/origin=].
     1. If |origin| is an [=opaque origin=], then return false.
+    1. Let |globalObject| be the [=current realm=]'s [=global object=].
+    1. [=Assert=] that |globalObject| is a {{Window}} or a {{SharedStorageWorkletGlobalScope}}.
+    1. If |globalObject| is a {{Window}}, and the result of executing [=is feature enabled|Is feature enabled in document for origin?=] on "[=PermissionsPolicy/shared-storage=]", |globalObject|'s [=associated Document=], and |origin| is "`Disabled`", return false.
     1. If the result of running [=obtaining a site|obtain a site=] with |origin| is not [=enrolled=], then return false.
     1. If the result of running [=check if user preference setting allows access to shared storage=] from |environment| is false, then return false.
     1. Return true.
   </div>
 
   <div algorithm>
-    To <dfn>check if addModule allowed and update status</dfn> for a {{SharedStorageWorklet}} |worklet|, run the following steps:
+    To <dfn>check if addModule is allowed and update status</dfn> for a {{SharedStorageWorklet}} |worklet|, run the following steps:
     1. If the result of running [=determine whether shared storage is allowed=] on the [=relevant settings object=] of [=this=] is false, return false.
     1. If |worklet|'s [=addModule initiated=] is true, return false.
     1. Set |worklet|'s [=addModule initiated=] to true.
@@ -271,7 +277,7 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
 
   In particular, the {{Worklet/addModule()}} method steps for {{Worklet}} will need to be prepended with the following step:
 
-    0. If {{Worklet}} has an associated boolean [=addModule initiated=], and the result of running [=check if addModule allowed and update status=] on {{Worklet}} is false, return a [=promise rejected=] with a {{TypeError}}.
+    0. If {{Worklet}} has an associated boolean [=addModule initiated=], and the result of running [=check if addModule is allowed and update status=] on {{Worklet}} is false, return a [=promise rejected=] with a {{TypeError}}.
 
   And the penultimate step (i.e. the final indented step), currently "If |pendingTasks| is 0, then resolve |promise|.", should be updated to:
 
@@ -941,9 +947,13 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |resultPromise| be a new [=promise=].
     1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. Let |document| be |context|'s [=active document=].
+    1. If |document| is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
+
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
-    1. If |environment|'s [=associated document=] is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
     1. If the result of running [=determine whether shared storage is allowed=] on |environment| is false, return a [=promise rejected=] with a {{TypeError}}.
+    1. Let |origin| be |document|'s [=url/origin=].
+    1. If the result of executing [=is feature enabled|Is feature enabled in document for origin?=] on "[=PermissionsPolicy/shared-storage-select-url=]", |document], and |origin| is "`Disabled`", return false.
     1. Let |worklet| be {{WindowSharedStorage}}'s {{WindowSharedStorage/worklet}}.
     1. If |worklet|'s [=global scopes|list of global scopes=] is [=list/empty=], then return a [=promise rejected=] with a {{TypeError}}.
     1. [=Assert=] that |worklet|'s [=global scopes|list of global scopes=] [=list/contains=] a single {{SharedStorageWorkletGlobalScope}}.
@@ -968,12 +978,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. Let |indexPromise| be the result of running [=get the select-url result index=], given |worklet|, |name|, |urlList|, and |options|.
     1. [=Upon fulfillment=] of |indexPromise|, perform the following steps:
         1. Let |resultIndex| be the numerical value of |indexPromise|.
-        1. Let |context| be {{WindowSharedStorage}}'s {{Window}}'s [=Window/browsing context=].
-        1. If |context| is null, let |resultURLWithMetadata| be |urls|[[=default index=]] and abort these steps.
-        1. Let |document| be |context|'s [=active document=].
-        1. If |document| is not [=fully active=], let |resultURLWithMetadata| be |urls|[[=default index=]] and abort these steps.
-        1. Let |origin| be |document|'s [=url/origin=].
-        1. [=Assert=] that |origin| is not [=opaque origin|opaque=].
         1. Let |remainingBudget| be the result of running [=determine remaining navigation budget=] with |environment| and |origin|.
         1. [=Assert=] that |remainingBudget| is not undefined.
         1. Let |pendingBits| be the logarithm base 2 of |urlList|'s [=list/size=].
@@ -1229,6 +1233,22 @@ On the other hand, methods for getting data from the [=shared storage database=]
         1. [=Queue a global task=] on the [=DOM manipulation task source=], given |realm|'s [=global object=], to resolve |promise| with |entry|.
     1. Return |promise|.
   </div>
+
+HTTP Response Header Integration {#http}
+========================================
+
+In addition to the ECMAScript APIs defined above to access [=shared storage=] from a {{Window}} or {{SharedStorageWorkletGlobalScope}}, setter and deleter operations can be triggered via HTTP Response Headers. 
+
+Permissions Policy Integration {#permission}
+============================================
+
+This specification defines a [=policy-controlled feature=] identified by the string "<dfn for="PermissionsPolicy">shared-storage</dfn>," along with a second [=policy-controlled feature=] identified by "<dfn for="PermissionsPolicy">shared-storage-select-url</dfn>".
+
+"[=PermissionsPolicy/shared-storage=]" gates access to Shared Storage in general, whereas "[=shared-storage-select-url=]" adds an exra permission layer to {{WindowSharedStorage/selectURL()}}. For each of these, the default allowlist is *.
+
+Clear Site Data Integration {#clear}
+====================================
+<span class=todo>Add details for Clear Site Data integration.</span>
 
 Privacy Considerations {#privacy}
 =================================

--- a/spec.bs
+++ b/spec.bs
@@ -949,7 +949,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
     1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |document| be |context|'s [=active document=].
     1. If |document| is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
-
     1. Let |environment| be |context|'s [=active window=]'s [=relevant settings object=].
     1. If the result of running [=determine whether shared storage is allowed=] on |environment| is false, return a [=promise rejected=] with a {{TypeError}}.
     1. Let |origin| be |document|'s [=url/origin=].
@@ -1233,11 +1232,6 @@ On the other hand, methods for getting data from the [=shared storage database=]
         1. [=Queue a global task=] on the [=DOM manipulation task source=], given |realm|'s [=global object=], to resolve |promise| with |entry|.
     1. Return |promise|.
   </div>
-
-HTTP Response Header Integration {#http}
-========================================
-
-In addition to the ECMAScript APIs defined above to access [=shared storage=] from a {{Window}} or {{SharedStorageWorkletGlobalScope}}, setter and deleter operations can be triggered via HTTP Response Headers. 
 
 Permissions Policy Integration {#permission}
 ============================================

--- a/spec.bs
+++ b/spec.bs
@@ -252,8 +252,7 @@ When {{Worklet/addModule()}} is called for a worklet, it will run [=check if add
     1. If |origin| is an [=opaque origin=], then return false.
     1. Let |globalObject| be the [=current realm=]'s [=global object=].
     1. [=Assert=] that |globalObject| is a {{Window}} or a {{SharedStorageWorkletGlobalScope}}.
-    1. Let |document| be |globalObject|'s [=associated Document=].
-    1. If |globalObject| is a {{Window}} and |document| is not [=allowed to use=] the "[=PermissionsPolicy/shared-storage=]" feature, return false.
+    1. If |globalObject| is a {{Window}} and |globalObject|'s [=associated Document=] is not [=allowed to use=] the "[=PermissionsPolicy/shared-storage=]" feature, return false.
     1. If the result of running [=obtaining a site|obtain a site=] with |origin| is not [=enrolled=], then return false.
     1. If the result of running [=check if user preference setting allows access to shared storage=] from |environment| is false, then return false.
     1. Return true.


### PR DESCRIPTION
We define Permissions Policy features for Shared Storage and include checks for whether they are enabled, along with a few other minor tweaks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/109.html" title="Last updated on Sep 5, 2023, 8:58 PM UTC (cd73167)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/109/0d7bffe...cd73167.html" title="Last updated on Sep 5, 2023, 8:58 PM UTC (cd73167)">Diff</a>