### PR TITLE
Update spec.bs: Add 'Sec-' prefix to request header

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1325,7 +1325,7 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
 
     add the step
 
-    1. [=Append or modify a Shared-Storage-Writable request header=] for |httpRequest|.
+    1. [=Append or modify a Sec-Shared-Storage-Writable request header=] for |httpRequest|.
   </div>
 
 ### Modification to [=HTTP fetch=] Algorithm ### {#mod-http-fetch}
@@ -1344,13 +1344,13 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
 
 ## Shared Storage HTTP Headers ## {#headers}
 
-### [:Shared-Storage-Writable:] Request Header ### {#request-header}
+### [:Sec-Shared-Storage-Writable:] Request Header ### {#request-header}
 
-  This specification defines a <dfn http-header>Shared-Storage-Writable</dfn> HTTP [=/request=] [=header=].
+  This specification defines a <dfn http-header>Sec-Shared-Storage-Writable</dfn> HTTP [=/request=] [=header=].
 
-  The [:Shared-Storage-Writable:] [=/request=] [=header=] is a [=Structured Header=] whose value must be a [=structured header/Boolean=].
+  The [:Sec-Shared-Storage-Writable:] [=/request=] [=header=] is a [=Structured Header=] whose value must be a [=structured header/Boolean=].
 
-  When a [=/request=] sets [:Shared-Storage-Writable:] to true its [=/response=] will be able to write to [=shared storage=].
+  When a [=/request=] sets [:Sec-Shared-Storage-Writable:] to true its [=/response=] will be able to write to [=shared storage=].
 
 ### [:Shared-Storage-Write:] Response Header ### {#response-header}
 
@@ -1401,20 +1401,20 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
 
 
   <div algorithm>
-    To <dfn>append or modify a Shared-Storage-Writable request header</dfn>, given a [=/request=] |request|, perform the following steps:
+    To <dfn>append or modify a Sec-Shared-Storage-Writable request header</dfn>, given a [=/request=] |request|, perform the following steps:
 
     1. If |request|'s [=request/shared storage writable=] is not true, then return.
 
         Note: On a redirect, it is possible for |request|'s [=request/shared storage writable=] to be true, but for the redirect not to have permission to use shared storage, making the result of running [=determine whether a request can currently use shared storage=] on |request| false.
 
-    1. If the result of running [=determine whether a request can currently use shared storage=] on |request| is false, [=header list/delete=] [:Shared-Storage-Writable:] from |request|'s [=request/header list=].
-    1. Otherwise, [=header list/set a structured field value=] ([:Shared-Storage-Writable:], true) in |request|'s [=request/header list=].
+    1. If the result of running [=determine whether a request can currently use shared storage=] on |request| is false, [=header list/delete=] [:Sec-Shared-Storage-Writable:] from |request|'s [=request/header list=].
+    1. Otherwise, [=header list/set a structured field value=] ([:Sec-Shared-Storage-Writable:], true) in |request|'s [=request/header list=].
   </div>
 
   <div algorithm>
     To <dfn>handle a Shared-Storage-Write response</dfn>, given a [=/response=] |response| and a [=/request=] |request|, perform the following steps:
 
-    1. Let |sharedStorageWritable| the result of running [=get a structured field value=] algorithm given [:Shared-Storage-Writable:], "`item`", and |request|'s [=request/header list=] as input.
+    1. Let |sharedStorageWritable| the result of running [=get a structured field value=] algorithm given [:Sec-Shared-Storage-Writable:], "`item`", and |request|'s [=request/header list=] as input.
     1. If |sharedStorageWritable| is null, or |sharedStorageWritable| is not a [=structured header/Boolean=], or the value of |sharedStorageWritable| is false, return.
     1. Let |window| to |request|’s [=request/window=].
     1. [=Assert=] that |window| is an [=environment settings object=] whose [=global object=] is a {{Window}}.


### PR DESCRIPTION
The request header added to requests that are eligible to write to shared storage via response header ought to be a "forbidden header" according to the [Fetch specification](https://fetch.spec.whatwg.org/#forbidden-request-header), i.e. a header that JS cannot add or modify.

We were using `Shared-Storage-Writable` as the name of the request header, which was not a forbidden header and could be modified by JS.

This commit is a followup to #120 and updates the specification draft to add the prefix `Sec-` in order to make this header forbidden. The new request header attached to eligible outgoing requests will be `Sec-Shared-Storage-Writable: ?1`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/121.html" title="Last updated on Oct 20, 2023, 8:03 PM UTC (941f4c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/121/edd815c...941f4c4.html" title="Last updated on Oct 20, 2023, 8:03 PM UTC (941f4c4)">Diff</a>