### PR TITLE
Make Shared-Storage-Write a forbidden response header

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1346,7 +1346,7 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
 
 ### [:Sec-Shared-Storage-Writable:] Request Header ### {#request-header}
 
-  This specification defines a <dfn http-header>Sec-Shared-Storage-Writable</dfn> HTTP [=/request=] [=header=].
+  This specification defines a <dfn http-header>Sec-Shared-Storage-Writable</dfn> HTTP [=/request=] [=header=]. Note that the '`sec-`' prefix makes [:Sec-Shared-Storage-Writable:] a [=forbidden request-header=].
 
   The [:Sec-Shared-Storage-Writable:] [=/request=] [=header=] is a [=Structured Header=] whose value must be a [=structured header/Boolean=].
 
@@ -1354,7 +1354,7 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
 
 ### [:Shared-Storage-Write:] Response Header ### {#response-header}
 
-  This specification defines a <dfn http-header>Shared-Storage-Write</dfn> HTTP [=/response=] [=header=].
+  This specification defines a <dfn http-header>Shared-Storage-Write</dfn> HTTP [=/response=] [=header=]. It also adds [:Shared-Storage-Write:] to the list of [=forbidden response-header name|forbidden response-headers=].
 
   The [:Shared-Storage-Write:] [=/response=] [=header=] is a [=Structured Header=] whose value must be a [=structured header/List=]. The following list members are defined. [=structured header/Tokens=] and [=structured header/Strings=] holding the same sequence of characters are considered equivalent. [=structured header/Byte Sequences=] representing [=UTF-8 encoded=] bytes are also allowed, in order to provide functionality for writing and deleting non-[=ASCII=] [=Unicode=] keys and values via HTTP headers.
 


### PR DESCRIPTION
We update spec.bs to include in the Fetch monkey patch that the new '`Shared-Storage-Write`' header should be added to the list of forbidden response headers. 

This will ensure that the '`Shared-Storage-Write`' response header can only be set by the server and read by the user agent. Frontend JavaScript will not be able to read, write, or modify it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/128.html" title="Last updated on Dec 18, 2023, 6:58 PM UTC (98b7ad6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/128/d19acf9...98b7ad6.html" title="Last updated on Dec 18, 2023, 6:58 PM UTC (98b7ad6)">Diff</a>