### PR TITLE
[spec] Use sequence instead of FrozenArray

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -227,7 +227,7 @@ The {{SharedStorageWorklet}} object allows developers to supply [=module scripts
   [Exposed=(Window)]
   interface SharedStorageWorklet : Worklet {
     Promise<SharedStorageResponse> selectURL(DOMString name,
-                                 FrozenArray<SharedStorageUrlWithMetadata> urls,
+                                 sequence<SharedStorageUrlWithMetadata> urls,
                                  optional SharedStorageRunOperationMethodOptions options = {});
     Promise<any> run(DOMString name,
                      optional SharedStorageRunOperationMethodOptions options = {});
@@ -995,7 +995,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
   [Exposed=(Window)]
   interface WindowSharedStorage : SharedStorage {
     Promise<SharedStorageResponse> selectURL(DOMString name,
-                                 FrozenArray<SharedStorageUrlWithMetadata> urls,
+                                 sequence<SharedStorageUrlWithMetadata> urls,
                                  optional SharedStorageRunOperationMethodOptions options = {});
     Promise<any> run(DOMString name,
                      optional SharedStorageRunOperationMethodOptions options = {});


### PR DESCRIPTION
This addresses issue https://github.com/WICG/shared-storage/issues/143. i.e. `FrozenArray<T>` should be prohibited as a parameter type in Web IDL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/162.html" title="Last updated on Jun 21, 2024, 4:05 PM UTC (aa5bfd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/162/919562d...aa5bfd4.html" title="Last updated on Jun 21, 2024, 4:05 PM UTC (aa5bfd4)">Diff</a>