### PR TITLE
Make run() signature consistent for selectURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Worklet script (i.e. `experiment.js`):
 class SelectURLOperation {
   hash(experimentName, seed) { … }
 
-  async run(data, urls) {
+  async run(urls, data) {
     const seed = await this.sharedStorage.get('seed');
     return hash(data.name, seed) % urls.length;
   }
@@ -315,7 +315,7 @@ In the worklet script (`creative-selection-by-frequency.js`):
 
 ```js
 class CreativeSelectionByFrequencyOperation {
-  async run(data, urls) {
+  async run(urls, data) {
     // By default, return the default url (0th index).
     let index = 0;
 


### PR DESCRIPTION
Some examples have run(data, urls) whereas the formal spec has run(urls, data) as the signature.

https://wicg.github.io/shared-storage/#get-the-select-url-result-index