### PR TITLE
[Explainer] Support Saved Queries in selectURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The shared storage worklet invocation methods (`addModule`, `run`, and `selectUR
         *   `savedQuery` (defaults to the empty string), a string naming the query to be saved or reused.
             *   If the value of `savedQuery` is nonempty and has not previously been associated with a [result index](#result-index) for call to `selectURL()` on the same page, and if the call to `selectURL()` succeeds:
                 *    The pair of (`savedQuery`, [`index`](#result-index)) will be stored for the lifetime of the page.
-                *    The shared storage data-owning origin's site can reuse the query from anywhere within the page.
+                *    The shared storage data origin's site can reuse the query from anywhere within the page.
             *   If the value of `savedQuery` is nonempty and has previously been associated with a [result index](#result-index) for a call to `selectURL()` on the same page, then: 
                 *    Instead of running the registered JavaScript operation, `selectURL()` will use the stored [result index](#result-index) associated with the value of `savedQuery` to choose the selected URL.
                 *    The [short-term per-page budgets](#Short-Term-Budgets) will not be charged.    

--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ The shared storage worklet invocation methods (`addModule`, `run`, and `selectUR
         *   `keepAlive` (defaults to false), a boolean denoting whether the worklet should be retained after it completes work for this call.
             *   If `keepAlive` is false or not specified, the worklet will shutdown as soon as the operation finishes and subsequent calls to it will fail.
             *   To keep the worklet alive throughout multiple calls to `run()` and/or `selectURL()`, each of those calls must include `keepAlive: true` in the `options` dictionary.
+        *   `savedQuery` (defaults to the empty string), a string naming the query to be saved or reused.
+            *   If the value of `savedQuery` is nonempty and has not previously been associated with a [result index](#result-index) for call to `selectURL()` on the same page, and if the call to `selectURL()` succeeds:
+                *    The pair of (`savedQuery`, [`index`](#result-index)) will be stored for the lifetime of the page.
+                *    The shared storage data-owning origin's site can reuse the query from anywhere within the page.
+            *   If the value of `savedQuery` is nonempty and has previously been associated with a [result index](#result-index) for a call to `selectURL()` on the same page, then: 
+                *    Instead of running the registered JavaScript operation, `selectURL()` will use the stored [result index](#result-index) associated with the value of `savedQuery` to choose the selected URL.
+                *    The [short-term per-page budgets](#Short-Term-Budgets) will not be charged.    
 *   `window.sharedStorage.run(name, options)`,  \
 `window.sharedStorage.selectURL(name, urls, options)`, …
     *   The behavior is identical to `window.sharedStorage.worklet.run(name, options)` and `window.sharedStorage.worklet.selectURL(name, urls, options)`.
@@ -167,7 +174,7 @@ The shared storage worklet invocation methods (`addModule`, `run`, and `selectUR
     *   Registers a shared storage worklet operation with the provided `name`.
     *   `operation` should be a class with an async `run()` method.
         *   For the operation to work with `sharedStorage.run()`, `run()` should take `data` as an argument and return nothing. Any return value is [ignored](#default).
-        *   For the operation to work with `sharedStorage.selectURL()`, `run()` should take `data` and `urls` as arguments and return the index of the selected URL. Any invalid return value is replaced with a [default return value](#default).
+        *   For the operation to work with `sharedStorage.selectURL()`, `run()` should take `data` and `urls` as arguments and return the <a name="result-index">index</a> of the selected URL. Any invalid return value is replaced with a [default return value](#default).
 
 
 ### In the worklet, during an operation
@@ -611,8 +618,21 @@ In the long term, `selectURL()` will leak bits of entropy on top-level navigatio
 
 In the short term, we have event-level reporting and less-restrictive [fenced frames](https://github.com/WICG/fenced-frame), which allow further leakage; thus it is necessary to impose additional limits. On top of the navigation bit budget described above, there will be two more budgets, each maintained on a per top-level navigation basis. The bit values for each call to `selectURL()` are calculated in the same way as detailed for the navigation bit budget.
 
-* Each page load will have a per-[site](https://html.spec.whatwg.org/multipage/browsers.html#site) bit budget of 6 bits for `selectURL()` calls. At the start of a new top-level navigation, this budget will refresh.
-* Each page load will also have an overall bit budget of 12 bits for `selectURL()`. This budget will be contributed to by all sites on the page. As with the per-[site](https://html.spec.whatwg.org/multipage/browsers.html#site) per-page load bit budget, this budget will refresh when the top frame navigates.
+* Each page load will have a per-[site](https://html.spec.whatwg.org/multipage/browsers.html#site) bit budget of 6 bits for `selectURL()` calls. At the start of a new top-level navigation, this budget will refresh. Saved queries named with the `savedQuery` option will only be charged against the budget on their initial use, not on any subsequent re-uses within the same page load. 
+* Each page load will also have an overall bit budget of 12 bits for `selectURL()`. This budget will be contributed to by all sites on the page. As with the per-[site](https://html.spec.whatwg.org/multipage/browsers.html#site) per-page load bit budget, this budget will refresh when the top frame navigates, and saved queries named with the `savedQuery` option will only be charged against the budget on their initial use, not on any subsequent re-uses within the same page load. 
+
+```javascript
+// Assuming that this call to `selectURL()` is the first to use 
+// `savedQuery: "control_or_experiment"` on this page, this call 
+// will be charged to both of the per-page budgets.
+const config1 = await sharedStorage.selectURL("experiment", urls1, {savedQuery: "control_or_experiment", keepAlive: true, resolveToConfig: true});
+document.getElementById("my-fenced-frame1").config = config1;
+
+// This next call will not be charged to either of the 
+// per-page budgets.
+const config2 = await sharedStorage.selectURL("experiment", urls2, {savedQuery: "control_or_experiment", resolveToConfig: true});
+document.getElementById("my-fenced-frame2").config = config2;
+```
 
 #### Enrollment and Attestation
 Use of Shared Storage requires [enrollment](https://github.com/privacysandbox/attestation/blob/main/how-to-enroll.md) and [attestation](https://github.com/privacysandbox/attestation/blob/main/README.md#core-privacy-attestations) via the [Privacy Sandbox enrollment attestation model](https://github.com/privacysandbox/attestation/blob/main/README.md).


### PR DESCRIPTION
`selectURL()` currently has two per-page-load budgets that restrict that number of calls made to `selectURL()` on each page-load.  We propose allowing queries to be saved and reused on a per-page basis, where the per-page-load budgets are charged the first time a saved query is run but not for subsequent runs of the saved query during the same page-load. This will be accomplished with a `savedQuery` parameter in the options for `selectURL()` that will name the query.