### PR TITLE
[spec] Add interestGroups()

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -149,7 +149,7 @@ spec: protected-audience; urlPrefix: https://wicg.github.io/turtledove/
         for: PermissionsPolicy
             text: run-ad-auction
             text: join-ad-interest-group
-        text: asynchronously finish reporting
+        text: get storage interest groups for owner
     type: interface
         text: StorageInterestGroup; url: dictdef-storageinterestgroup
 spec: fenced-frame; urlPrefix: https://wicg.github.io/fenced-frame/
@@ -786,7 +786,7 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
     1. Let |workletDataOrigin| be [=current realm=]'s [=realm/settings object=]'s [=environment settings object/origin=].
     1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/run-ad-auction=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
     1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/join-ad-interest-group=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
-    1. [=resolve=] |promise| with the result of running [=asynchronously finish reporting=].
+    1. [=resolve=] |promise| with the result of running [=get storage interest groups for owner=].
   </div>
 
   <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -786,7 +786,7 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
     1. Let |workletDataOrigin| be [=current realm=]'s [=realm/settings object=]'s [=environment settings object/origin=].
     1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/run-ad-auction=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
     1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/join-ad-interest-group=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
-    1. [=resolve=] |promise| with the result of running [=get storage interest groups for owner=].
+    1. [=Resolve=] |promise| with the result of running [=get storage interest groups for owner=].
   </div>
 
   <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -144,6 +144,14 @@ spec: private-aggregation-api; urlPrefix: https://patcg-individual-drafts.github
             text: scoping details; url: #privateaggregation-scoping-details
     type: interface
         text: PrivateAggregation
+spec: protected-audience; urlPrefix: https://wicg.github.io/turtledove/
+    type: dfn
+        for: PermissionsPolicy
+            text: run-ad-auction
+            text: join-ad-interest-group
+        text: asynchronously finish reporting
+    type: interface
+        text: StorageInterestGroup; url: dictdef-storageinterestgroup
 spec: fenced-frame; urlPrefix: https://wicg.github.io/fenced-frame/
     type: dfn
         text: fenced frame; url: the-fencedframe-element
@@ -736,6 +744,8 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
 
       readonly attribute SharedStorage sharedStorage;
       readonly attribute PrivateAggregation privateAggregation;
+
+      Promise<sequence<AuctionAdInterestGroup>> interestGroups();
     };
   </xmp>
 
@@ -762,6 +772,22 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
   </div>
 
   Issue(151): The "name" and "operationCtor" cannot be missing here given WebIDL. Should just check for default/empty values.
+
+  <div algorithm>
+    The <dfn method for="SharedStorageWorkletGlobalScope">interestGroups()</dfn> method steps are:
+
+    1. Let |promise| be a new [=promise=].
+    1. If the result of running [=SharedStorageWorkletGlobalScope/check whether addModule is finished=] for {{SharedStorage}}'s associated {{SharedStorageWorkletGlobalScope}} is false, return a [=promise rejected=] with a {{TypeError}}.
+    1. Let |globalObject| be the [=current realm=]'s [=global object=].
+    1. Let |context| be |globalObject|'s [=Window/browsing context=].
+    1. If |context| is null, return a [=promise rejected=] with a {{TypeError}}.
+    1. Let |document| be |context|'s [=active window=]'s [=associated document=].
+    1. If |document| is not [=fully active=], return a [=promise rejected=] with a {{TypeError}}.
+    1. Let |workletDataOrigin| be [=current realm=]'s [=realm/settings object=]'s [=environment settings object/origin=].
+    1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/run-ad-auction=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
+    1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/join-ad-interest-group=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
+    1. [=resolve=] |promise| with the result of running [=asynchronously finish reporting=].
+  </div>
 
   <div algorithm>
     The <dfn for="SharedStorageWorkletGlobalScope">{{SharedStorageWorkletGlobalScope/sharedStorage}} getter</dfn> steps are:

--- a/spec.bs
+++ b/spec.bs
@@ -745,7 +745,7 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
       readonly attribute SharedStorage sharedStorage;
       readonly attribute PrivateAggregation privateAggregation;
 
-      Promise<sequence<AuctionAdInterestGroup>> interestGroups();
+      Promise<sequence<StorageInterestGroup>> interestGroups();
     };
   </xmp>
 
@@ -786,7 +786,13 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
     1. Let |workletDataOrigin| be [=current realm=]'s [=realm/settings object=]'s [=environment settings object/origin=].
     1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/run-ad-auction=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
     1. If the result of running [=Is feature enabled in document for origin?=] on "[=PermissionsPolicy/join-ad-interest-group=]", |document|, and |workletDataOrigin| returns false, then return a [=promise rejected=] with a {{TypeError}}.
-    1. [=Resolve=] |promise| with the result of running [=get storage interest groups for owner=].
+    1. Run the following steps [=in parallel=]:
+        1. Let |interestGroups| be the result of running [=get storage interest groups for owner=] given |workletDataOrigin|.
+        1. If |interestGroups| is failure:
+            1. [=Queue a global task=] on the [=DOM manipulation task source=], given |realm|'s [=global object=], to [=reject=] |promise| with a {{TypeError}}.
+        1. Otherwise:
+            1. [=Queue a global task=] on the [=DOM manipulation task source=], given |realm|'s [=global object=], to [=resolve=] |promise| with |interestGroups|.
+    1. Return |promise|.
   </div>
 
   <div algorithm>


### PR DESCRIPTION
This is the Shared Storage side's spec update to support interestGroups() within shared storage worklet (https://github.com/WICG/shared-storage/pull/180). Sibling spec update PR for Protected Audience: https://github.com/WICG/turtledove/pull/1299.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/203.html" title="Last updated on Oct 31, 2024, 4:59 PM UTC (5924478)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/203/8121c4e...5924478.html" title="Last updated on Oct 31, 2024, 4:59 PM UTC (5924478)">Diff</a>