### PR TITLE
Spec: use PAA coordinator algorithm

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -511,17 +511,9 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
         does not [=map/exist=], return null.
     1. If |options|["{{SharedStorageRunOperationMethodOptions/privateAggregationConfig}}"]["{{SharedStoragePrivateAggregationConfig/aggregationCoordinatorOrigin}}"]
         does not [=map/exist=], return null.
-    1. Let |url| be the result of running the [=URL parser=] on
+    1. Return the result of [=obtaining the Private Aggregation coordinator=]
+        given
         |options|["{{SharedStorageRunOperationMethodOptions/privateAggregationConfig}}"]["{{SharedStoragePrivateAggregationConfig/aggregationCoordinatorOrigin}}"].
-    1. If |url| is failure or null, return a new {{DOMException}} with name
-        "`SyntaxError`".
-
-        Issue: Consider throwing an error if the path is not empty.
-    1. Let |origin| be |url|'s [=url/origin=].
-    1. If the result of [=determining if an origin is an aggregation coordinator=]
-        given |origin| is false, return a new {{DOMException}} with name
-        "`DataError`".
-    1. Return |origin|.
   </div>
 
   <div algorithm>


### PR DESCRIPTION
Switches to using the exported algorithm from the Private Aggregation spec (which will be used in Protected Audience's spec as well)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/204.html" title="Last updated on Oct 21, 2024, 9:29 PM UTC (76906ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/204/e3b4368...76906ef.html" title="Last updated on Oct 21, 2024, 9:29 PM UTC (76906ef)">Diff</a>