### PR TITLE
Fix references to dataOrigin in createWorklet algo

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1466,7 +1466,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     The <dfn method for="SharedStorage">createWorklet(|moduleURL|, |options|)</dfn> method steps are:
 
     1. Let |sharedStorageWorklet| be a new {{SharedStorageWorklet}}.
-    1. If |options| [=map/contains=] |dataOrigin|, set |sharedStorageWorklet|'s [=SharedStorageWorklet/data origin=] to |options|[|dataOrigin|].
+    1. If |options| [=map/contains=] "{{SharedStorageWorkletOptions/dataOrigin}}", set |sharedStorageWorklet|'s [=SharedStorageWorklet/data origin=] to |options|["{{SharedStorageWorkletOptions/dataOrigin}}"].
     1. Let |addModulePromise| be the result of invoking sharedStorageWorklet.{{Worklet/addModule()|addModule}}(|moduleURL|, |options|).
     1. Let |resultPromise| be a new [=promise=].
     1. [=Upon fulfillment=] of |addModulePromise|, [=resolve=] |resultPromise| to |sharedStorageWorklet|.


### PR DESCRIPTION
We update mentions of `dataOrigin` in the `createWorklet` algo to be references.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/208.html" title="Last updated on Nov 23, 2024, 12:40 AM UTC (03fa7ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/208/0eccc1d...03fa7ca.html" title="Last updated on Nov 23, 2024, 12:40 AM UTC (03fa7ca)">Diff</a>