### PR TITLE
[spec] Web Locks integration: support navigator.locks in the worklet

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -859,7 +859,10 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
 
   Each {{SharedStorageWorkletGlobalScope}} also has an associated <dfn for=SharedStorageWorkletGlobalScope>operation map</dfn>, which is a [=map=], initially empty, of [=strings=] (denoting operation names) to [=function objects=].
 
-  Each {{SharedStorageWorkletGlobalScope}} also has an associated {{SharedStorage}} instance, with the [=SharedStorageWorkletGlobalScope/sharedStorage getter=] algorithm as described below.
+  Each {{SharedStorageWorkletGlobalScope}} has an associated {{SharedStorage}} instance <dfn for=SharedStorageWorkletGlobalScope>shared storage instance</dfn>.
+
+  Each {{SharedStorageWorkletGlobalScope}} has an associated {{SharedStorageWorkletNavigator}} instance <dfn for=SharedStorageWorkletGlobalScope>navigator instance</dfn>.
+
 
   ### {{SharedStorageWorkletGlobalScope}} algorithms ### {#scope-algo}
   <div algorithm>
@@ -898,9 +901,16 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
   </div>
 
   <div algorithm>
-    The <dfn for="SharedStorageWorkletGlobalScope">{{SharedStorageWorkletGlobalScope/sharedStorage}} getter</dfn> steps are:
+    The <dfn attribute for=SharedStorageWorkletGlobalScope>sharedStorage</dfn> [=getter steps=] are:
 
-    1. If [=this=]'s [=addModule success=] is true, return [=this=]'s {{SharedStorageWorkletGlobalScope/sharedStorage}}.
+    1. If [=this=]'s [=addModule success=] is true, return [=this=]'s [=SharedStorageWorkletGlobalScope/shared storage instance=].
+    1. Otherwise, throw a {{TypeError}}.
+  </div>
+
+  <div algorithm>
+    The <dfn attribute for=SharedStorageWorkletGlobalScope>navigator</dfn> [=getter steps=] are:
+
+    1. If [=this=]'s [=addModule success=] is true, return [=this=]'s [=SharedStorageWorkletGlobalScope/navigator instance=].
     1. Otherwise, throw a {{TypeError}}.
   </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -21,6 +21,7 @@ spec:infra;
 spec:webidl;
     type:interface;
         text:double
+        text:long
     type:dfn;
         text:an exception was thrown
 spec:html;
@@ -2048,7 +2049,7 @@ A <dfn>shared storage lock managers map</dfn> is a [=map=] of [=/origins=] to [=
 
 A [=user agent=] has an associated [=shared storage lock managers map=].
 
-Note: Similar to its data partitioning, the shared storage has its own lock management scope, independent of the Storage Buckets API.
+Note: Similar to its data partitioning, the shared storage has its own lock management scope, independent of the Storage Buckets API. These web locks will not interact with web locks created from Window or Worker via the existing, legacy Web Locks API.
 
 ## {{SharedStorageWorkletNavigator}} interface ## {#shared-storage-worklet-navigator-interface}
 

--- a/spec.bs
+++ b/spec.bs
@@ -2044,7 +2044,7 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
 
 ## User Agent Associated State ## {#user-agent-associated-state}
 
-A <dfn>shared storage lock managers map</dfn> is a [=map=] of [=/origins=] to [=lock manager=]. It is initially empty.
+A <dfn>shared storage lock managers map</dfn> is a [=map=] of [=/origins=] to [=lock managers=]. It is initially empty.
 
 A [=user agent=] has an associated [=shared storage lock managers map=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -94,6 +94,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 spec: beacon; urlPrefix: https://w3c.github.io/beacon/
     type: dfn
         text: beacon; url: beacon
+spec: web-locks; urlPrefix: https://w3c.github.io/web-locks/
+    type: dfn
+        text: lock manager; url: lock-manager
+        text: obtain a lock manager; url: obtain-a-lock-manager
 spec: ecma; urlPrefix: https://tc39.es/ecma262/
     type: dfn
         text: call; url: sec-call
@@ -844,6 +848,8 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
       readonly attribute PrivateAggregation privateAggregation;
 
       Promise<sequence<StorageInterestGroup>> interestGroups();
+
+      readonly attribute SharedStorageWorkletNavigator navigator;
     };
   </xmp>
 
@@ -2022,6 +2028,58 @@ The IDL attribute {{HTMLSharedStorageWritableElementUtils/sharedStorageWritable}
     1. If |parameters| does not [=map/contain=] |paramKey|, return null.
     1. If |parameters|[|paramKey|] is not a [=structured header/Boolean=], return null.
     1. Return |parameters|[|paramKey|].
+  </div>
+
+# Web Locks Integration # {#web-locks-integration}
+
+## User Agent Associated State ## {#user-agent-associated-state}
+
+A <dfn>shared storage lock managers map</dfn> is a [=map=] of [=/origins=] to [=lock manager=]. It is initially empty.
+
+A [=user agent=] has an associated [=shared storage lock managers map=].
+
+Note: Similar to its data partitioning, the shared storage has its own lock management scope, independent of the Storage Buckets API.
+
+## {{SharedStorageWorkletNavigator}} interface ## {#shared-storage-worklet-navigator-interface}
+
+<xmp class='idl'>
+[
+  Exposed=SharedStorageWorklet,
+] interface SharedStorageWorkletNavigator {};
+</xmp>
+
+## Web Locks IDLs Monkey Patches ## {#web-locks-api-monkey-patches}
+
+Include the {{NavigatorLocks}} mixin in {{SharedStorageWorkletNavigator}} (i.e., let {{SharedStorageWorkletNavigator}} contain a {{LockManager}} instance):
+
+<xmp class='idl'>
+SharedStorageWorkletNavigator includes NavigatorLocks;
+</xmp>
+
+The {{LockManager}} and {{Lock}} are additionally exposed to SharedStorageWorklet:
+
+<xmp class='idl'>
+[SecureContext, Exposed=(Window,Worker,SharedStorageWorklet)]
+interface LockManager {};
+</xmp>
+
+<xmp class='idl'>
+[SecureContext, Exposed=(Window,Worker,SharedStorageWorklet)]
+interface Lock {};
+</xmp>
+
+## Monkey Patch for lock manager's description ## {#monkey-patch-for-lock-manager-description}
+
+Add the following sentence at the end of the paragraph that defines [=lock manager=]: "Additionally, each user agent includes one [=shared storage lock managers map=] for Web Locks API's integration with the Shared Storage API."
+
+## Monkey Patch for the "obtain a lock manager" algorithm ## {#monkey-patch-for-the-obtain-a-lock-manager-algorithm}
+
+The [=obtain a lock manager=] algorithm should be prepended with the following steps:
+
+  <div algorithm='monkey-patch-obtain-a-lock-manager'>
+    1. If [=current realm=]'s [=global object=] is a {{SharedStorageWorkletGlobalScope}}:
+        1. Let |workletDataOrigin| be <var ignore=''>environment</var>'s [=environment settings object/origin=].
+        1. Return [=shared storage lock managers map=][|workletDataOrigin|].
   </div>
 
 Permissions Policy Integration {#permission}


### PR DESCRIPTION
This is part of the Web Locks integration proposal:
https://github.com/WICG/shared-storage/pull/199
https://github.com/WICG/shared-storage/pull/205

How: Let user agent hold a map of origins to lock managers, and for the existing Web Locks API's algorithm, use this manager for shared storage cases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/pull/209.html" title="Last updated on Dec 16, 2024, 6:49 AM UTC (f0325f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/209/dc07b5a...f0325f5.html" title="Last updated on Dec 16, 2024, 6:49 AM UTC (f0325f5)">Diff</a>