### PR TITLE
Pedantic improvements to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+spec.html
+spec-remote.html

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
- SHELL=/bin/bash
+SHELL = /bin/bash
 
-local: spec.bs
-	bikeshed --die-on=warning spec spec.bs spec.html
+# Automatically delete any target whose recipe fails.
+.DELETE_ON_ERROR:
 
 spec.html: spec.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
-	                       --output spec.html \
-	                       --write-out "%{http_code}" \
-	                       --header "Accept: text/plain, text/html" \
-	                       -F die-on=warning \
-	                       -F file=@spec.bs) && \
-	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
-		echo ""; cat spec.html; echo ""; \
-		rm -f spec.html; \
-		exit 22 \
-	);
+	bikeshed --die-on=warning spec $< $@
 
-remote: spec.html
+spec-remote.html: spec.bs
+	trap 'echo; cat $@; echo;' ERR;          \
+	curl >$@ https://api.csswg.org/bikeshed/ \
+	       --no-progress-meter               \
+	       --fail-with-body                  \
+	       --form die-on=warning             \
+	       --form file=@$<
+
+# These targets do not correspond to files.
+.PHONY: local remote clean
+
+local: spec.html
+
+remote: spec-remote.html
+	cp $< spec.html
 
 clean:
-	rm spec.html
+	rm -f spec.html spec-remote.html


### PR DESCRIPTION
The highlights:

* Make can now skip unnecessary work when our targets are already up to date.
* The remote-build recipe now delegates failure detection to curl and preserves its exit status.
* The `clean` target is no longer picky about whether files exist.
* Generated files are now listed in `.gitignore`.



@pythagoraskitty and @xyaoinum, PTAL!
