### PR TITLE
[spec] Enable per-context contribution limits for Private Aggregation

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -133,6 +133,7 @@ spec: private-aggregation-api; urlPrefix: https://patcg-individual-drafts.github
         for: pre-specified report parameters
             text: context ID
             text: filtering ID max bytes
+            text: max contributions
         text: batching scope
         text: debug scope
         text: process contributions for a batching scope
@@ -579,11 +580,20 @@ Moreover, each {{SharedStorageWorklet}}'s [=global scopes|list of global scopes=
         1. If |filteringIdMaxBytes| is not the [=default filtering ID max bytes=] or
             |contextId| is not null, return a new {{DOMException}} with name
             "`DataError`".
+    1. Let |maxContributions| be null.
+    1. If
+        |privateAggregationConfig|["{{SharedStoragePrivateAggregationConfig/maxContributions}}"]
+        [=map/exists=], set |maxContributions| to
+        |privateAggregationConfig|["{{SharedStoragePrivateAggregationConfig/maxContributions}}"].
+    1. If |maxContributions| is zero, return a new {{DOMException}} with name
+        "`DataError`".
     1. Return a new [=pre-specified report parameters=] with the items:
         : <a spec="private-aggregation-api" for="pre-specified report parameters">context ID</a>
         :: |contextId|
         : [=pre-specified report parameters/filtering ID max bytes=]
         :: |filteringIdMaxBytes|
+        : [=pre-specified report parameters/max contributions=]
+        :: |maxContributions|
   </div>
 
   <div algorithm>
@@ -1604,6 +1614,7 @@ On the other hand, methods for getting data from the [=shared storage database=]
     USVString aggregationCoordinatorOrigin;
     USVString contextId;
     [EnforceRange] unsigned long long filteringIdMaxBytes;
+    [EnforceRange] unsigned long long maxContributions;
   };
 
   dictionary SharedStorageRunOperationMethodOptions {


### PR DESCRIPTION
The goal is to enable Shared Storage embedders to override the default number of contributions per Private Aggregation report.

To that end, this change adds the `maxContributions` field to the web-visible Private Aggregation config dictionary and plumbs its value into Private Aggregation's "pre-specified report parameters".

Context:
* Explainer: patcg-individual-drafts/private-aggregation-api#146
* Spec change: patcg-individual-drafts/private-aggregation-api#164


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmcardle/shared-storage/pull/216.html" title="Last updated on Jan 16, 2025, 4:28 PM UTC (e98524b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/shared-storage/216/6df142d...dmcardle:e98524b.html" title="Last updated on Jan 16, 2025, 4:28 PM UTC (e98524b)">Diff</a>