### PR TITLE
Re-enable builds for PRs in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build
 on:
+  pull_request: 
+    branches:
+      - main
+    paths:
+      - "**.bs"
   push:
     branches: [main]
     paths: ["**.bs"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Build
 on:
   pull_request: 
-    branches:
-      - main
-    paths:
-      - "**.bs"
+    branches: [main]
+    paths: ["**.bs"]
   push:
     branches: [main]
     paths: ["**.bs"]


### PR DESCRIPTION
PR-Preview is currently [broken](https://github.com/tobie/pr-preview/issues/161) with no fix ETA, so there's no spec builds occurring for new PRs. There should probably be some build checks in place, even if we can't immediately see a preview for the build.

I used the instructions [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request) to reconfigure this check for `.bs` file changes only.